### PR TITLE
Remove run dependency to libboost-devel

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
     - 5eff1ecc8413b0dc93a1ab047d7fed751e6cb40e.patch  # [not win]
 
 build:
-  number: 1
+  number: 2
+  run_exports:
+    - libboost-mpi
 
 requirements:
   build:
@@ -23,8 +25,6 @@ requirements:
     - {{ mpi }}
 
   run:
-    # explicitly depend on -devel version because we need the headers
-    - libboost-devel {{ version }}.*
     - {{ mpi }}
 
   run_constrained:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Installing `libboost-mpi` should not install `libboost-devel` but only the libraries.